### PR TITLE
docs(workflow): update branch strategy to reflect two-tier protection

### DIFF
--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -2,8 +2,10 @@
 
 ## Protected Branches
 
-- `main` - Production-ready code
-- `develop` - Integration branch for features
+### Main Branch (`main`)
+- Production-ready code
+- Strict protection rules
+- Used for releases
 
 ## Branch Naming
 
@@ -12,32 +14,33 @@
 - Documentation: `docs/description`
 - Release branches: `release/version`
 
-## Workflow
-
-1. Create a new branch from `develop`
-2. Make your changes
-3. Create a Pull Request to `develop`
-4. After review and approval, merge to `develop`
-5. Periodically merge `develop` into `main` for releases
-
 ## Protection Rules
 
 ### Main Branch
-
 - No direct pushes
 - Requires pull request
 - Requires approval from at least one reviewer
 - Must pass all status checks
 - Must have linear history (no merge commits)
+- Must be up to date before merging
 
-### Develop Branch
-
+### All Other Branches
 - No direct pushes
 - Requires pull request
 - Must pass all status checks
+- Must be up to date before merging
+- Allows merge commits
+- Flexible merge strategies (merge, squash, rebase)
+
+## Workflow
+
+1. Create a new feature branch with appropriate prefix
+2. Make your changes
+3. Create a Pull Request
+4. Address review comments
+5. Merge after approval and passing checks
 
 ## Status Checks Required
-
-- Commit message validation
+- Commit message validation (conventional commits)
 - Code style checks (coming soon)
 - Tests (coming soon)


### PR DESCRIPTION
Updates our branching strategy documentation to reflect our actual two-tier protection setup (main vs all other branches).